### PR TITLE
Pep8 to be tested

### DIFF
--- a/Sources/watchdog.py
+++ b/Sources/watchdog.py
@@ -1215,7 +1215,7 @@ class Monitor:
         map(self.addService, services)
 
     def runnerForRule(self, rule, context, iteration):
-        if self.runners.has_key(rule.id):
+        if rule.id in self.runners.keys():
             self.logger.err("Previous iteration's rule is still running: %s, you should increase its frequency." % (rule))
             return None
         else:


### PR DESCRIPTION
These commits are a bit more intrusive in your code. They consist into two major types:
- "has_key" function is deprecated and preferred to the construct "in",
- some data variables were set and not used afterwards. Sometimes I've deleted the lines, on one occasion, I've just commented them out, because I wasn't sure this wasn't here by design.

Anyway, IMHO, these commits need to be tested before being merged into master.
