### PR TITLE
The runner should be stored in the dictionary, not a value of True.

### DIFF
--- a/Sources/daemonwatch.py
+++ b/Sources/daemonwatch.py
@@ -1251,7 +1251,7 @@ class Monitor:
 			return None
 		else:
 			runner = Runner.Create(rule, context=context, iteration=iteration)
-			self.runners[runner.runnable.id] = True
+			self.runners[runner.runnable.id] = runner
 			if runner:
 				runner.onRunEnded(self.onRuleEnded)
 				return runner


### PR DESCRIPTION
I was trying to run an HTTP monitor and was getting the following error:

```
Traceback (most recent call last):
  File "monitor.py", line 33, in <module>
    run_monitor(sys.argv[1])
  File "monitor.py", line 22, in run_monitor
    Print("%s experienced 5 errors within 5 seconds")
  File "/Users/mattwright/Workspace/Change-By-Us/scripts/daemonwatch.py", line 1278, in run
    runner = self.runnerForRule(rule, service, self.iteration)
  File "/Users/mattwright/Workspace/Change-By-Us/scripts/daemonwatch.py", line 1248, in runnerForRule
    if iteration - runner.iteration < 5:
AttributeError: 'bool' object has no attribute 'iteration'
```

This fixed the problem
