### PR TITLE
Do not run System.CPUStats when booting. This isn't OS-safe

### DIFF
--- a/Sources/monitoring.py
+++ b/Sources/monitoring.py
@@ -1688,8 +1688,6 @@ class Monitor:
 
 SUCCESS = Success()
 FAILURE = Failure()
-# Updates the CPU stats so that CPUUsage works
-System.CPUStats()
 
 def command(args):
 	if len(args) != 1:


### PR DESCRIPTION
When running monitoring on my mac it immediately fails b/c the file `/proc/stat` doesn't exist. 
So I removed the call to `System.CPUStats()` when initializing. 
As a matter of fact - since at least in my use case what I'm monitoring isn't localhost, it's a remote host, then I don't really care about cpu stats on localhost, not when initializing and not forever. But even if I did, this method isn't generally compatible with all OSes. 
Plus I don't know why/if it really needs to be triggered by default during initialization. 
So I just took a wild guess and removed it. Is this the correct thing? :grin: 
